### PR TITLE
GSoC IntelOwl "more" sections

### DIFF
--- a/content/blog/2020/08/26/gsoc-2020-work-product - intel-owl/index.md
+++ b/content/blog/2020/08/26/gsoc-2020-work-product - intel-owl/index.md
@@ -1,13 +1,15 @@
 ---
-title: "GSoC 2020 Work Product - Intel Owl"
+title: "GSoC 2020 Project Summary: A new front-end and analyzers for IntelOwl"
 date: "2020-08-26"
-categories: 
-  - "gsoc"
-tags: 
-  - "intelowl"
-  - "threatintel"
 coverImage: "intel_owl.jpeg"
+tags: ["gsoc", "intelowl", "threatintel"]
 ---
+
+Our [GSoC](https://summerofcode.withgoogle.com/) student [Eshaan Bansal](https://github.com/Eshaan7) was working for three months under the supervision of Matteo Lodi on the OSINT platform [IntelOwl](https://github.com/intelowlproject/IntelOwl), specifically introducing a brand new front-end written in Angular and analyzers to automate integrations.
+
+Read on for an overview of their achievements and how they successfully contributed towards IntelOwl and some considerations for the future.
+
+<!--more-->
 
 **Student**: Eshaan Bansal ([@Eshaan7](https://github.com/Eshaan7))  
 **Mentor:** [Matteo Lodi](https://twitter.com/matte_lodi) and [Pietro Delsante](https://twitter.com/PietroDelsante)**  
@@ -16,8 +18,6 @@ Organization**: The Honeynet Project
 **Tag**: Information Security
 
 ### Project Overview
-
-#### Intel Owl
 
 Intel Owl is an Open Source Intelligence, or OSINT solution to get threat intelligence data about a specific file, an IP or a domain from a single API at scale. It integrates a number of analyzers available online and is for everyone who needs a single point to query for info about a specific file or observable.
 

--- a/content/blog/2021/08/20/gsoc-2021-project-summary-intelowl-connectors-manager-and-integrations/index.md
+++ b/content/blog/2021/08/20/gsoc-2021-project-summary-intelowl-connectors-manager-and-integrations/index.md
@@ -1,30 +1,29 @@
 ---
 title: "GSoC 2021 Project Summary: IntelOwl Connectors Manager and Integrations"
 date: "2021-08-20"
-categories: 
-  - "gsoc"
-tags: 
-  - "gsoc-d20"
-  - "intelowl"
-  - "threatintel"
 coverImage: "intel_owl_positive_reduced.png"
+tags: ["gsoc", "intelowl", "threatintel"]
 ---
+
+Our [GSoC](https://summerofcode.withgoogle.com/) student [Shubham Pandey](https://github.com/sp35/) was working for three months under the supervision of Matteo Lodi on the OSINT platform [IntelOwl](https://github.com/intelowlproject/IntelOwl), specifically introducing the connector manager allowing for powerful integrations with external data sources.
+
+Read on for an overview of their achievements and how they successfully contributed towards IntelOwl and some considerations for the future.
+
+<!--more-->
 
 Student: Shubham Pandey ([@sp35](https://github.com/sp35/))
 
-Mentor: [Eshaan Bansal](https://twitter.com/mask0fmydisguis) and [Matteo Lodi](https://twitter.com/matte_lodi)
+Mentors: [Eshaan Bansal](https://twitter.com/mask0fmydisguis) and [Matteo Lodi](https://twitter.com/matte_lodi)
 
 Organization: The Honeynet Project
 
-Project: [Intel Owl](https://github.com/intelowlproject/IntelOwl)
+Project: [IntelOwl](https://github.com/intelowlproject/IntelOwl)
 
-Tag: Information Security
+## **Project Overview**
 
-### **Project Overview**
+IntelOwl is an Open Source Intelligence or OSINT solution to get threat intelligence data about a specific file, an IP, or a domain from a single API at scale. It integrates a number of analyzers available online and is for everyone who needs a single point to query for info about a specific file or observable.
 
-Intel Owl is an Open Source Intelligence or OSINT solution to get threat intelligence data about a specific file, an IP, or a domain from a single API at scale. It integrates a number of analyzers available online and is for everyone who needs a single point to query for info about a specific file or observable.
-
-### **Shubham's GSoC Proposal**
+## **Shubham's GSoC Proposal**
 
 As cited in my original proposal’s overview:
 
@@ -32,7 +31,7 @@ _I propose a new component of the project - a connectors manager which would hel
 
 So the main objective was to develop a connectors manager which would help IntelOwl connect with any SOAR/SIEM platform, particularly for threat-intel sharing purposes.
 
-### **Pre GSoC Commits**
+## **Pre GSoC Commits**
 
 List of pull requests merged before GSoC’s coding period:
 
@@ -41,24 +40,24 @@ List of pull requests merged before GSoC’s coding period:
 - CLI commands and library methods for the python client - kill ongoing analysis ([#68](https://github.com/intelowlproject/pyintelowl/pull/68)) and delete a job ([#71](https://github.com/intelowlproject/pyintelowl/pull/71))
 - Reusable UI components for image(base64) visualization ([#88](https://github.com/intelowlproject/IntelOwl-ng/pull/88)), social links ([#91](https://github.com/intelowlproject/IntelOwl-ng/pull/91))
 
-### **GSoC Tasks and Deliverables**
+## **GSoC Tasks and Deliverables**
 
-#### 1\. Connectors Manager
+### 1\. Connectors Manager
 
 A common pattern observed in analyzers’ python modules was the validation of secrets configured via a JSON configuration file. Also, a user while requesting an analysis, couldn’t know if an analyzer was configured properly or not. This was something that would affect the new component - connectors as well.
 
 I and Sarthak (who worked on the analyzers part of this issue) used DRF’s serializers to validate the configuration file initially and cached it for the rest of the application’s lifecycle while invalidating the cache if the file was changed. We used the design pattern \`Abstract Factory\` and created abstract classes to extend this for both analyzers and connectors ([#499](https://github.com/intelowlproject/IntelOwl/pull/499), [#518](https://github.com/intelowlproject/IntelOwl/pull/518)).
 
-#### 2\. Plugin, Connector, controllers, data classes
+### 2\. Plugin, Connector, controllers, data classes
 
 - Initially, I refactored the existing workflow for running analyzers and tried extending it to run connectors as well. Knowing that it was a temporary solution, after discussion with Eshaan and Sarthak, we decided to create an abstract class \`Plugin\` providing a common base which the subclasses \`BaseAnalyzer\` and  \`Connector\` would extend upon. This required a lot of refactoring and was a conflicting task which blocked the addition of new features as well. Even though Eshaan was our mentor, he gave a significant contribution through code as well, so that we could manage to wrap this up quickly ([#524](https://github.com/intelowlproject/IntelOwl/pull/524)).
 - Used python data classes for handling config dictionaries and enums wherever possible so as to avoid incorrect property references ([#530](https://github.com/intelowlproject/IntelOwl/pull/530), [#544](https://github.com/intelowlproject/IntelOwl/pull/544)).
 
-#### 3\. MISP, OpenCTI, YETI connectors
+### 3\. MISP, OpenCTI, YETI connectors
 
 Finally, it was time to work on some integrations using connectors. Integrations were added for threat-intel sharing platforms - MISP ([#528](https://github.com/intelowlproject/IntelOwl/pull/528)), OpenCTI ([#602](https://github.com/intelowlproject/IntelOwl/pull/602)), YETI ([#631](https://github.com/intelowlproject/IntelOwl/pull/631)). It also made sense to leverage the opportunity to add analyzers that would search for observables/threat-intel reports available on these platforms - OpenCTI ([#603](https://github.com/intelowlproject/IntelOwl/pull/603)), YETI ([#632](https://github.com/intelowlproject/IntelOwl/pull/632)).
 
-#### 4\. Plugins Actions - kill, retry, health-check
+### 4\. Plugins Actions - kill, retry, health-check
 
 I proposed that connectors would have a \`kill\` feature to stop any ongoing/pending connector run and \`retry\` to restart any failed/killed connector run. Another action health-check was considered to check if the associated instances (docker containers and external platforms) were up or not, anytime, instead of finding out later in a failed analysis. Once again abstract classes were used to extend these to both analyzers and connectors.
 
@@ -66,7 +65,7 @@ I proposed that connectors would have a \`kill\` feature to stop any ongoing/pen
 2. Since celery tasks cannot be restarted, retry was implemented by constructing the same arguments and starting a new celery task ([#582](https://github.com/intelowlproject/IntelOwl/pull/582)). 
 3. The health check feature was added to docker-based analyzers and connectors ([#627](https://github.com/intelowlproject/IntelOwl/pull/627)).
 
-#### 5\. IntelOwl-ng (UI changes)
+### 5\. IntelOwl-ng (UI changes)
 
 All the corresponding user interface changes were committed to the repo [IntelOwl-ng (Angular app)](https://github.com/intelowlproject/IntelOwl-ng).
 
@@ -74,13 +73,13 @@ All the corresponding user interface changes were committed to the repo [IntelOw
 2. Added components and services for kill/retry ([#125](https://github.com/intelowlproject/IntelOwl-ng/pull/125)), and health-check ([#135](https://github.com/intelowlproject/IntelOwl-ng/pull/135)) actions.
 3. Other improvements and refactors ([#129](https://github.com/intelowlproject/IntelOwl-ng/pull/129), [#137](https://github.com/intelowlproject/IntelOwl-ng/pull/137), [#119](https://github.com/intelowlproject/IntelOwl-ng/pull/119))
 
-#### 6\. Pyintelowl client
+### 6\. Pyintelowl client
 
 All the corresponding changes to the python client were committed to the repo [Pyintelowl (python client)](https://github.com/intelowlproject/pyintelowl).
 
 Added CLI commands and library methods for fetching connectors’ configuration ([#112](https://github.com/intelowlproject/pyintelowl/pull/112)), plugin actions kill/retry ([#113](https://github.com/intelowlproject/pyintelowl/pull/113)), and health-check ([#114](https://github.com/intelowlproject/pyintelowl/pull/114)).
 
-### **Next Steps**
+## **Next Steps**
 
 I’m very glad to have worked on this amazing project and would continue to do so even after GSoC. In the future, we shall be working on these features:
 

--- a/content/blog/2021/08/20/gsoc-2021-project-summary-intelowl-improvements/index.md
+++ b/content/blog/2021/08/20/gsoc-2021-project-summary-intelowl-improvements/index.md
@@ -1,14 +1,15 @@
 ---
 title: "GSoC 2021 Project Summary: IntelOwl Improvements"
 date: "2021-08-20"
-categories: 
-  - "gsoc"
-tags: 
-  - "gsoc-d20"
-  - "intelowl"
-  - "threatintel"
 coverImage: "intel_owl_positive_reduced.png"
+tags: ["gsoc", "intelowl", "threatintel"]
 ---
+
+Our [GSoC](https://summerofcode.withgoogle.com/) student [Sarthak Khattar](https://github.com/m0mosenpai) was working for three months under the supervision of Matteo Lodi on the OSINT platform [IntelOwl](https://github.com/intelowlproject/IntelOwl), specifically overhauling the analyzer configuration, API and test suite refactoring, and the integration of new analyzers.
+
+Read on for an overview of their achievements and how they successfully contributed towards IntelOwl and some considerations for the future.
+
+<!--more-->
 
 **Student:** Sarthak Khattar ([GitHub](https://github.com/m0mosenpai))
 
@@ -17,8 +18,6 @@ coverImage: "intel_owl_positive_reduced.png"
 **Organization:** The Honeynet Project
 
 **Project:** [IntelOwl](https://github.com/intelowlproject/IntelOwl)
-
-**Tag:** Information Security
 
 ### **Project Overview**
 

--- a/content/blog/2022/09/06/gsoc-2022-project-summary-intelowl-go-client-go-intelowl/index.md
+++ b/content/blog/2022/09/06/gsoc-2022-project-summary-intelowl-go-client-go-intelowl/index.md
@@ -2,8 +2,14 @@
 title: "GSoC 2022 Project Summary: IntelOwl Go Client (go-intelowl)"
 date: "2022-09-06"
 coverImage: "intel_owl_positive_reduced.png"
-tags: ["osint", "intelowl", "threatintel"]
+tags: ["gsoc", "intelowl", "threatintel"]
 ---
+
+Our [GSoC](https://summerofcode.withgoogle.com/) student [Hussain Khan](https://github.com/fear-the-reaper) was working for three months under the supervision of Matteo Lodi on the OSINT platform [IntelOwl](https://github.com/intelowlproject/IntelOwl), specifically on a Go client library, allowing developers to integrate with the IntelOwl API in their solutions.
+
+Read on for an overview of their achievements and how they successfully contributed towards IntelOwl and some considerations for the future.
+
+<!--more-->
 
 **Student**: Hussain Khan ([@fear-the-reaper](https://github.com/fear-the-reaper))
 
@@ -11,17 +17,15 @@ tags: ["osint", "intelowl", "threatintel"]
 
 **Organization**: The Honeynet Project
 
-**Project**: [Intel Owl](https://github.com/intelowlproject/IntelOwl)
+**Project**: [IntelOwl](https://github.com/intelowlproject/IntelOwl)
 
 **Project Overview**
 
-Intel Owl is an Open Source Intelligence or OSINT solution to get threat intelligence data about a specific file, an IP, or a domain from a single API at scale. It integrates a number of analyzers available online and is for everyone who needs a single point to query for info about a specific file or observable.
-
-<!--more-->
+IntelOwl is an Open Source Intelligence or OSINT solution to get threat intelligence data about a specific file, an IP, or a domain from a single API at scale. It integrates a number of analyzers available online and is for everyone who needs a single point to query for info about a specific file or observable.
 
 **Hussain’s proposal:**
 
-_I propose making a robust Go client library for OSINT Threat Intelligence Platform IntelOwl that easily communicates with their API. The Intelowl Go SDK will allow developers to communicate with the API so that they can easily develop and integrate IntelOwl with their own automated scripts, tools, and services._ 
+_I propose making a robust Go client library for OSINT Threat Intelligence Platform IntelOwl that easily communicates with their API. The IntelOwl Go SDK will allow developers to communicate with the API so that they can easily develop and integrate IntelOwl with their own automated scripts, tools, and services._ 
 
 So the main objective was to develop a robust Go client library that is easy to use for developers and easily extensible for adding new features.
 
@@ -30,7 +34,7 @@ So the main objective was to develop a robust Go client library that is easy to 
 List of pull requests merged before GSoC’s coding period:
 
 - Adding a new issue template where I added markdown templates for adding a new issue and analyzer [(#904](https://github.com/intelowlproject/IntelOwl/pull/904)).  
-- Patching the FLOSS analyzer where I researched adding the eXpert flag. This was a really fun issue where I thoroughly understood how intelowl’s analyzers are configured and how they are executed ([#940](https://github.com/intelowlproject/IntelOwl/pull/940)).  
+- Patching the FLOSS analyzer where I researched adding the eXpert flag. This was a really fun issue where I thoroughly understood how IntelOwl’s analyzers are configured and how they are executed ([#940](https://github.com/intelowlproject/IntelOwl/pull/940)).  
     
 
 **GSoC Tasks and Deliverables**

--- a/content/blog/2022/09/26/gsoc-2022-project-summary-intelowl-v4-improvements/index.md
+++ b/content/blog/2022/09/26/gsoc-2022-project-summary-intelowl-v4-improvements/index.md
@@ -2,8 +2,13 @@
 title: "GSoC 2022 Project Summary: IntelOwl v4 Improvements"
 date: "2022-09-26"
 coverImage: "intel_owl_positive_reduced.png"
-tags: ["osint", "intelowl", "threatintel"]
+tags: ["gsoc", "intelowl", "threatintel"]
 ---
+Our [GSoC](https://summerofcode.withgoogle.com/) student [Aditya Pratap Singh](https://github.com/devmrfitz) was working for three months under the supervision of Matteo Lodi on the OSINT platform [IntelOwl](https://github.com/intelowlproject/IntelOwl), specifically on bulk analysis, single sign-on, and major improvements to the configurations and secrets.
+
+Read on for an overview of their achievements and how they successfully contributed towards IntelOwl and some considerations for the future.
+
+<!--more-->
 
 **Student**: Aditya Pratap Singh ([devmrfitz](https://github.com/devmrfitz))
 
@@ -11,13 +16,11 @@ tags: ["osint", "intelowl", "threatintel"]
 
 **Organization**: The Honeynet Project
 
-**Project**: [Intel Owl](https://github.com/intelowlproject/IntelOwl)
+**Project**: [IntelOwl](https://github.com/intelowlproject/IntelOwl)
 
 **Project Overview**
 
 Intel Owl is an Open Source Intelligence or OSINT solution to get threat intelligence data about a specific file, an IP, or a domain from a single API at scale. It integrates a number of analyzers available online and is for everyone who needs a single point to query for info about a specific file or observable.
-
-<!--more-->
 
 **Aditya’s proposal:**
 
@@ -47,7 +50,7 @@ Here's an overview of the features I had implemented by my mid-evaluation:
 - Allowed bulk analysis of files as well as observables, leading to a more efficient workflow for IntelOwl users. [#1032](https://github.com/intelowlproject/IntelOwl/pull/1032)
 - Improved the rendering of JSON job result data [#1051](https://github.com/intelowlproject/IntelOwl/pull/1051)
 - Edited `FileInfo` analyzer to add some more potentially useful hashes. [#1073](https://github.com/intelowlproject/IntelOwl/pull/1073)
-- Implemented a feature that felicitated editing of plugin parameters directly from GUI as well as setting of default parameters at organization level, thus making IntelOwl more customizable and easier to use. [#1095](https://github.com/intelowlproject/IntelOwl/pull/1095)
+- Implemented a feature that facilitated editing of plugin parameters directly from GUI as well as setting of default parameters at organization level, thus making IntelOwl more customizable and easier to use. [#1095](https://github.com/intelowlproject/IntelOwl/pull/1095)
 - Added an `extends` field of config files. This allowed configs to extend from other similar config, thus eliminating unnecessary code duplication. [#1119](https://github.com/intelowlproject/IntelOwl/pull/1119)
 
 I still felt I was going slightly wrong somewhere. My mid-evaluation report directed me to the problem. I was again not communicating enough, the very same mistake I had made last year. Due to the distributed nature of any popular FOSS project's community, it is very essential that seemingly minor implementation decisions (like the positioning of a button) should be discussed before being actually coded. This helps the community's developers to avoid writing as well as peer-reviewing unnecessary code.
@@ -59,9 +62,9 @@ Finally we come to today's status. I'm almost done with all the issues I set out
 - Added "Login with Google" support to IntelOwl to allow easier and secure user onboarding. [#1129](https://github.com/intelowlproject/IntelOwl/pull/1129)
 - \[The pending one\] Allowed secure editing of plugin secrets from IntelOwl's GUI. Earlier, the secrets could only be edited by manually modifying a specific file on the server. Also, implemented organization-level secrets. [#1136](https://github.com/intelowlproject/IntelOwl/pull/1136)
 
-The merging of this final PR will conclude my GSoC journey. I learnt a lot more than I initially set out to. The most valuable lessons are, infact, not even technical in nature. I learnt how to better work with a team, especially one spread over various timezones.
+The merging of this final PR will conclude my GSoC journey. I learnt a lot more than I initially set out to. The most valuable lessons are, in fact, not even technical in nature. I learnt how to better work with a team, especially one spread over various timezones.
 
-As an ending note, I would like to give a huge thanks to my mentor, Matteo Lodi. He was with me every step of the way, even when my work was not upto the mark.  
+As an ending note, I would like to give a huge thanks to my mentor, Matteo Lodi. He was with me every step of the way, even when my work was not up to the mark.  
 Thanks a lot Matteo :)
 
 Original post is available [here](https://dev.to/devmrfitz/to-gsoc-and-beyond-4m34)

--- a/content/blog/2022/10/06/gsoc-2022-project-summary-creating-playbooks-for-intelowl/index.md
+++ b/content/blog/2022/10/06/gsoc-2022-project-summary-creating-playbooks-for-intelowl/index.md
@@ -2,8 +2,14 @@
 title: "GSoC 2022 Project summary: Creating Playbooks for IntelOwl"
 date: "2022-10-06"
 coverImage: "intel_owl_positive_reduced.png"
-tags: ["osint", "intelowl", "threatintel"]
+tags: ["gsoc", "intelowl", "threatintel"]
 ---
+
+Our [GSoC](https://summerofcode.withgoogle.com/) student [Aditya Narayan Sinha](https://github.com/0x0elliot) was working for three months under the supervision of Matteo Lodi on the OSINT platform [IntelOwl](https://github.com/intelowlproject/IntelOwl), specifically on introducing playbooks that define automated actions associated with the observation of a specific indicator of compromise.
+
+Read on for an overview of their achievements and how they successfully contributed towards IntelOwl and some considerations for the future.
+
+<!--more-->
 
 **Student**: Aditya Narayan Sinha ([0x0elliot](https://github.com/0x0elliot))
 
@@ -11,9 +17,7 @@ tags: ["osint", "intelowl", "threatintel"]
 
 **Organization**: The Honeynet Project
 
-**Project**: [Intel Owl](https://github.com/intelowlproject/IntelOwl)
-
-<!--more-->
+**Project**: [IntelOwl](https://github.com/intelowlproject/IntelOwl)
 
 ### **Aditya’s GSoC Proposal:**
 
@@ -72,6 +76,6 @@ One of the main problems I encountered while working was syncing up with the oth
 
 I am thankful for my supportive and brilliant mentors for giving me this chance and being there every step of the way. If they weren't there, I am sure I wouldn't have it made it so far. Someone trusting in you always pushes you ahead more than you can think.
 
-I want to be there more with HoneyPot to accommodate in developing the projects they look forward to developing with my special interest being in GreedyBear https://github.com/honeynet/GreedyBear/. It is a project that is still being developed and has a lot of scopes for things to build.
+I want to be there more with HoneyPot to accommodate in developing the projects they look forward to developing with my special interest being in [GreedyBear](https://github.com/honeynet/GreedyBear/). It is a project that is still being developed and has a lot of scopes for things to build.
 
-I also want to help out with providing Go-IntelOwl support for Playbooks. It is something that wasn’t planned or promised in my original proposal. But Hussain, One of the other contributors to the IntelOwl project, Ended up completing the CLI by the time we all finished with our GSoC projects. As of now, it lacks Playbook support. So that would be the natural thing for me to move forward to adding.
+I also want to help out with providing Go-IntelOwl support for Playbooks. It is something that wasn’t planned or promised in my original proposal. But Hussain, one of the other contributors to the IntelOwl project, ended up completing the CLI by the time we all finished with our GSoC projects. As of now, it lacks Playbook support. So that would be the natural thing for me to move forward to adding.


### PR DESCRIPTION
@mlodic I added a "more" section to all the GSoC InterOwl posts to make them display better in the blog post list. You cans see them [here](http://localhost:1313/tags/intelowl/) if you run it locally (we don't have branch deploys yet).
I was a little creative when writing the summaries but tried to understand as much as possible from the students posts.